### PR TITLE
Ignore dunder methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Configuration options also exist:
  - `unused-arguments-ignore-nested-functions` - don't show warnings for nested
    functions. Only show warnings for functions in the top level of a module, or methods
    of a class in the top level of a module.
-
+ - `unused-arguments-ignore-dunder` - don't show warnings for double-underscore methods.
+   These methods implement or override native builtin methods which have a specific
+   signature. Therefore arguments must always be present. This is the case of methods
+   like `__new__`, `__init__`, `__getitem__`, `__setitem__`, `__reduce_ex__`,
+   `__enter__`, `__exit__`, etc.
 
 ## Changelog
 

--- a/test_unused_arguments.py
+++ b/test_unused_arguments.py
@@ -264,6 +264,48 @@ def test_is_stub_function(function, expected_result):
         ),
         (
             """
+            class Foo:
+                def __new__(cls):
+                    return []
+                def __enter__(self):
+                    return self
+                def __exit__(self, exc_tp, exc_v, exc_tb):
+                    return False
+                def __setattr__(self, item, value):
+                    raise ValueError("read-only")
+                def __reduce_ex__(self, protocol):
+                    return Foo, ()
+            """,
+            {"ignore_dunder_methods": False},
+            [
+                (3, 16, "U100 Unused argument 'cls'", "unused argument"),
+                (7, 23, "U100 Unused argument 'exc_tp'", "unused argument"),
+                (7, 31, "U100 Unused argument 'exc_v'", "unused argument"),
+                (7, 38, "U100 Unused argument 'exc_tb'", "unused argument"),
+                (9, 26, "U100 Unused argument 'item'", "unused argument"),
+                (9, 32, "U100 Unused argument 'value'", "unused argument"),
+                (11, 28, "U100 Unused argument 'protocol'", "unused argument"),
+            ],
+        ),
+        (
+            """
+            class Foo:
+                def __new__(cls):
+                    return []
+                def __enter__(self):
+                    return self
+                def __exit__(self, exc_tp, exc_v, exc_tb):
+                    return False
+                def __setattr__(self, item, value):
+                    raise ValueError("read-only")
+                def __reduce_ex__(self, protocol):
+                    return Foo, ()
+            """,
+            {"ignore_dunder_methods": True},
+            [],
+        ),
+        (
+            """
     def foo(_a):
         pass
     """,


### PR DESCRIPTION
Another option, this time for dunder methods.
The use case if that many dunder methods require arguments, like

```
class Foo:
  def __setitem__(self, item, value):
    raise ValueError("readonly")
  def __reduce_ex__(self, protocol):
    return ...
  def __exit__(self, exc_tp, exc_val, exc_tb):
    ...
```

IDEs will happily generate these methods for us, and people expect them to have certain signatures.

Also fixes https://github.com/nhoad/flake8-unused-arguments/issues/4 

PS: you don't need to put my name on the README. The git history is enough. Thank you :) 