### PR TITLE
Update is_dunder_method to pass type checking

### DIFF
--- a/flake8_unused_arguments.py
+++ b/flake8_unused_arguments.py
@@ -261,8 +261,12 @@ def is_stub_function(function: FunctionTypes) -> bool:
 def is_dunder_method(function: FunctionTypes) -> bool:
     if isinstance(function, ast.Lambda):
         return False
+
+    if not hasattr(function, "name"):
+        return False
+
     name = function.name
-    return name and len(name) > 4 and name.startswith("__") and name.endswith("__")
+    return len(name) > 4 and name.startswith("__") and name.endswith("__")
 
 
 class FunctionFinder(NodeVisitor):


### PR DESCRIPTION
Type checking fails with the response:

```
flake8_unused_arguments.py:265: error: Incompatible return value type (got "Union[str, bool]", expected "bool")  [return-value]
```

This PR fixes this type issue by checking the name is a function attribute before checking it starts and ends with "__".