### PR TITLE
Add CI workflow to run tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Continuos Integration
+
+on: [pull_request, push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run_tox:
+    name: Run tox
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: 3.8
+
+      - name: Install base and testing dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run Tox
+        run: tox

--- a/test_unused_arguments.py
+++ b/test_unused_arguments.py
@@ -402,6 +402,7 @@ def test_integration(function, options, expected_warnings):
         assert warnings == expected_warnings
 
 
+@pytest.mark.release
 def test_check_version() -> None:
     from flake8_unused_arguments import Plugin
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
     pytest
     flake8
 commands =
-    pytest test_unused_arguments.py
+    pytest test_unused_arguments.py -m "not release"
 
 ; run mypy for type checking
 [testenv:py38-mypy]
@@ -30,3 +30,7 @@ commands=
 [flake8]
 max-line-length = 88
 ignore = E501,W503
+
+[pytest]
+markers =
+    release: mark a test as release related.


### PR DESCRIPTION
This PR adds a workflow to run tox for all pull requests. The workflow will fail initially but will be fixed once #19 is merged. One test was also not appropriate to be run in this workflow as it relates to checking that the current commit is tagged with the same tag as the current version, however this fails as the new tag will not be added until the PR is merged.