### PR TITLE
Add option to ignore methods with `@override`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package adds the following warnings:
 Configuration options also exist:
  - `unused-arguments-ignore-abstract-functions` - don't show warnings for abstract functions.
  - `unused-arguments-ignore-overload-functions` - don't show warnings for overload functions.
+ - `unused-arguments-ignore-override-functions` - don't show warnings for overridden functions.
  - `unused-arguments-ignore-stub-functions` - don't show warnings for empty functions.
  - `unused-arguments-ignore-variadic-names` - don't show warnings for unused *args and **kwargs.
  - `unused-arguments-ignore-lambdas` - don't show warnings for all lambdas.

--- a/flake8_unused_arguments.py
+++ b/flake8_unused_arguments.py
@@ -16,6 +16,7 @@ class Plugin:
 
     ignore_abstract = False
     ignore_overload = False
+    ignore_override = False
     ignore_stubs = False
     ignore_variadic_names = False
     ignore_lambdas = False
@@ -43,6 +44,15 @@ class Plugin:
             default=cls.ignore_overload,
             dest="unused_arguments_ignore_overload_functions",
             help="If provided, then unused arguments for functions decorated with overload will be ignored.",
+        )
+
+        option_manager.add_option(
+            "--unused-arguments-ignore-override-functions",
+            action="store_true",
+            parse_from_config=True,
+            default=cls.ignore_override,
+            dest="unused_arguments_ignore_override_functions",
+            help="If provided, then unused arguments for functions decorated with override will be ignored.",
         )
 
         option_manager.add_option(
@@ -100,6 +110,7 @@ class Plugin:
     def parse_options(cls, options: optparse.Values) -> None:
         cls.ignore_abstract = options.unused_arguments_ignore_abstract_functions
         cls.ignore_overload = options.unused_arguments_ignore_overload_functions
+        cls.ignore_override = options.unused_arguments_ignore_override_functions
         cls.ignore_stubs = options.unused_arguments_ignore_stub_functions
         cls.ignore_variadic_names = options.unused_arguments_ignore_variadic_names
         cls.ignore_lambdas = options.unused_arguments_ignore_lambdas
@@ -115,6 +126,10 @@ class Plugin:
 
             # ignore overload functions, it's not a surprise when they're empty
             if self.ignore_overload and "overload" in decorator_names:
+                continue
+
+            # ignore overridden functions
+            if self.ignore_override and "override" in decorator_names:
                 continue
 
             # ignore abstractmethods, it's not a surprise when they're empty

--- a/test_unused_arguments.py
+++ b/test_unused_arguments.py
@@ -196,6 +196,24 @@ def test_is_stub_function(function, expected_result):
         ),
         (
             """
+    @override
+    def foo(a):
+        pass
+    """,
+            {"ignore_override": False},
+            [(3, 8, "U100 Unused argument 'a'", "unused argument")],
+        ),
+        (
+            """
+    @override
+    def foo(a):
+        pass
+    """,
+            {"ignore_override": True},
+            [],
+        ),
+        (
+            """
     def foo(a):
         pass
     """,


### PR DESCRIPTION
closes #18 

Python 3.12 [will have a new @override decorator](https://peps.python.org/pep-0698/) to mark methods that are overriding a method in a base class:
```python
from typing import override

class Parent:
    def foo(self, x: int) -> int:
        return x + 1

class Child(Parent):
    @override
    def foo(self, x: int) -> int:
        return 2
```
Type checkers can then verify that the override has the correct signature.

And we don't have to wait until Python 3.12 is released because the decorator can already be used today with [typing-extensions](https://pypi.org/project/typing-extensions/): `from typing_extensions import override`.